### PR TITLE
Add PDF generation template and view for CV export. Not finished (wea…

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import CVListView, CVDetailView
+from .views import CVDetailPDFView, CVListView, CVDetailView
 
 urlpatterns = [
     path('', CVListView.as_view(), name='cv_list'),
     path('cv/<int:pk>/', CVDetailView.as_view(), name='cv_detail'),
+    path('cv/<int:pk>/pdf/', CVDetailPDFView.as_view(), name='cv_pdf'),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -1,6 +1,7 @@
 from django.db.models import Prefetch
-from django.views.generic import DetailView
-from django.views.generic import ListView
+from django.views.generic import ListView, DetailView
+# from django_weasyprint import WeasyTemplateResponseMixin
+# from django.http import HttpResponseServerError
 
 from .models import CV, Contact, Project, Skill
 
@@ -32,3 +33,28 @@ class CVDetailView(DetailView):
                      queryset=Project.objects.order_by('-start_date')),
             Prefetch('contacts', queryset=Contact.objects.all())
         )
+
+
+class CVDetailPDFView(DetailView):
+    pass
+# class CVDetailPDFView(WeasyTemplateResponseMixin, DetailView):
+#     model = CV
+#     template_name = 'main/cv_pdf.html'
+#     pdf_filename = 'cv_{pk}.pdf'
+#
+#     def get_pdf_filename(self):
+#         return f'cv_{self.object.first_name}_{self.object.last_name}.pdf'.lower()
+#
+#     def get_queryset(self):
+#         return CV.objects.prefetch_related(
+#             Prefetch('skills', queryset=Skill.objects.all()),
+#             Prefetch('projects',
+#                      queryset=Project.objects.order_by('-start_date')),
+#             Prefetch('contacts', queryset=Contact.objects.all())
+#         )
+#
+#     def get(self, request, *args, **kwargs):
+#         try:
+#             return super().get(request, *args, **kwargs)
+#         except Exception as e:
+#             return HttpResponseServerError(f"Error generating PDF: {str(e)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "django (==4.2.10)"
+    "django (==4.2.10)",
 ]
 
 

--- a/templates/main/cv_detail.html
+++ b/templates/main/cv_detail.html
@@ -24,6 +24,11 @@
                        class="bg-gray-100 text-gray-700 px-4 py-2 rounded hover:bg-gray-200">
                         Back to List
                     </a>
+                    <a href="{% url 'cv_pdf' cv.pk %}"
+                       class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+                        <i class="fas fa-download mr-2"></i>
+                        Download PDF
+                    </a>
                 </div>
 
                 <!-- Bio -->

--- a/templates/main/cv_pdf.html
+++ b/templates/main/cv_pdf.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ cv.first_name }} {{ cv.last_name }} - CV</title>
+    <style>
+        @page {
+            size: A4;
+            margin: 2.5cm 2cm;
+            @top-right {
+                content: "Page " counter(page) " of " counter(pages);
+            }
+        }
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        .header {
+            margin-bottom: 2em;
+        }
+        .name {
+            font-size: 24px;
+            font-weight: bold;
+            margin-bottom: 0.5em;
+        }
+        .contacts {
+            margin-bottom: 1em;
+        }
+        .section {
+            margin-bottom: 2em;
+        }
+        .section-title {
+            font-size: 18px;
+            font-weight: bold;
+            border-bottom: 1px solid #ccc;
+            margin-bottom: 1em;
+        }
+        .skills-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1em;
+        }
+        .project {
+            margin-bottom: 1.5em;
+        }
+        .project-header {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 0.5em;
+        }
+        .project-title {
+            font-weight: bold;
+        }
+        .project-date {
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div class="name">{{ cv.first_name }} {{ cv.last_name }}</div>
+        <div class="contacts">
+            {% for contact in cv.contacts.all %}
+                <div>{{ contact.get_type_display }}: {{ contact.value }}</div>
+            {% endfor %}
+        </div>
+        <div class="bio">{{ cv.bio }}</div>
+    </div>
+
+    <div class="section">
+        <div class="section-title">Skills</div>
+        <div class="skills-grid">
+            {% for skill in cv.skills.all %}
+                <div class="skill">
+                    <div>{{ skill.name }}</div>
+                    <div>{{ skill.get_proficiency_display }}</div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="section-title">Projects</div>
+        {% for project in cv.projects.all %}
+            <div class="project">
+                <div class="project-header">
+                    <span class="project-title">{{ project.title }}</span>
+                    <span class="project-date">
+                        {{ project.start_date|date:"M Y" }} -
+                        {% if project.end_date %}
+                            {{ project.end_date|date:"M Y" }}
+                        {% else %}
+                            Present
+                        {% endif %}
+                    </span>
+                </div>
+                <div>{{ project.description }}</div>
+                {% if project.url %}
+                    <div>Project URL: {{ project.url }}</div>
+                {% endif %}
+            </div>
+        {% endfor %}
+    </div>
+
+    {% if cv.education.all %}
+        <div class="section">
+            <div class="section-title">Education</div>
+            {% for edu in cv.education.all %}
+                <div class="education">
+                    <div>{{ edu.institution }}</div>
+                    <div>{{ edu.degree }}</div>
+                    <div>{{ edu.start_date|date:"Y" }} - {{ edu.end_date|date:"Y" }}</div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
…syprint adaptation left)

This commit creates a new PDF template (`cv_pdf.html`) for exporting CVs in a printable format. It also introduces a `CVDetailPDFView` and updates the URLs and frontend to support PDF downloads. Placeholder implementation for the view is included with commented-out code for further enhancements.